### PR TITLE
feat(dx): add perf middleware to log action dispatch time

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-router-redux": "^2.1.0",
     "redux": "^3.1.4",
     "redux-actions": "^0.9.1",
+    "redux-perf-middleware": "^1.0.1",
     "redux-thunk": "^1.0.3",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.12",

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -16,8 +16,13 @@ export default history => {
     ? window.devToolsExtension()
     : f => f
 
+  const perf = (process.env.BROWSER && !isProduction)
+    ? applyMiddleware(require('redux-perf-middleware').default)
+    : f => f
+
   const enhancers = compose(
     applyMiddleware(syncHistory(history), thunk),
+    perf,
     devTools
   )
 


### PR DESCRIPTION
Might be redundant with redux devTools, but I find it interesting to have it.