### PR TITLE
Revert "chore(yarn): treat as binary"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-yarn.lock -diff


### PR DESCRIPTION
This reverts commit 0348ecca9740809985914809537b86d373bbf13c.